### PR TITLE
BYUVRX phase 3 submission for 2022 vrx

### DIFF
--- a/2022/phase3_vrx_challenge/byuvrx/component_config.yaml
+++ b/2022/phase3_vrx_challenge/byuvrx/component_config.yaml
@@ -24,6 +24,8 @@ wamv_imu:
       x: 0.3
       y: 0.0
       z: 1.3
+# wamv_p3d:
+#     - name: p3d_wamv
 lidar:
     - name: lidar_wamv
       x: 0.75
@@ -31,3 +33,5 @@ lidar:
       z: 1.6
       type: 16_beam
       P: ${radians(15)}
+wamv_pinger:
+    - name: pinger


### PR DESCRIPTION
This is a resubmission, we found out our component config was missing the pinger for task 5. Should be active for tasks 1-5 now, and task 6 should have no movement.